### PR TITLE
fix Option/Validated tests that pass in a assertion

### DIFF
--- a/src/test/kotlin/io/kotest/assertions/arrow/OptionMatchersTest.kt
+++ b/src/test/kotlin/io/kotest/assertions/arrow/OptionMatchersTest.kt
@@ -43,7 +43,10 @@ class OptionMatchersTest : WordSpec() {
         option shouldBe beSome("foo")
         option shouldBeSome "foo"
 
-        option shouldBeSome { it == "foo" }
+        option shouldBeSome { it shouldBe "foo" }
+        shouldThrow<AssertionError> {
+           option shouldBeSome { it shouldNotBe "foo" }
+        }
       }
     }
 

--- a/src/test/kotlin/io/kotest/assertions/arrow/ValidatedMatchersTest.kt
+++ b/src/test/kotlin/io/kotest/assertions/arrow/ValidatedMatchersTest.kt
@@ -13,6 +13,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 class ValidatedMatchersTest : StringSpec({
 
@@ -25,7 +26,10 @@ class ValidatedMatchersTest : StringSpec({
       Valid("ok") should beValid()
       Valid("ok").shouldBeValid()
       Valid("ok") shouldBeValid "ok"
-      Valid("ok") shouldBeValid { it.value == "ok" }
+      Valid("ok") shouldBeValid { it.value shouldBe "ok" }
+      shouldThrow<AssertionError> {
+         Valid("ok") shouldBeValid { it.value shouldNotBe "ok" }
+      }
 
       shouldThrow<AssertionError> {
          Valid("ok") shouldNotBeValid "ok"
@@ -51,7 +55,10 @@ class ValidatedMatchersTest : StringSpec({
       Invalid("error") should beInvalid()
       Invalid("error").shouldBeInvalid()
       Invalid("error") shouldBeInvalid "error"
-      Invalid("error") shouldBeInvalid { it.value == "error" }
+      Invalid("error") shouldBeInvalid { it.value shouldBe "error" }
+      shouldThrow<AssertionError> {
+         Invalid("error") shouldBeInvalid { it.value shouldNotBe "error" }
+      }
       Invalid("error").shouldNotBeValid()
    }
 


### PR DESCRIPTION
while experimenting with the matchers i noticed that the tests for `Option` and `Validated` pass in a predicate instead of an assertion to `shouldBeSome` and `shouldBeValid/shouldBeInvalid`. The result of the predicate won't have any effect. I have changed the tests and also added a negative test that exposes the issue.